### PR TITLE
Add Subject type to the project, add \api\subjects route that returns mock data, and use the mock API data in the grid

### DIFF
--- a/app/api/subjects/route.ts
+++ b/app/api/subjects/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Sleep function to mock API latency
+ * @param ms time in milliseconds
+ * @returns Promise<void>
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * GET /api/subjects
+ * Returns a list of subjects after waiting for 0.1 seconds
+ * @returns Promise<void>
+ */
+export async function GET() {
+  // Simulate API latency
+  await sleep(100);
+  return NextResponse.json(subjects);
+}
+
+const subjects = [
+  {
+    id: 1,
+    name: "Sophia Kim",
+    age: 28,
+    gender: "F",
+    diagnosisDate: "2024-08-09",
+    status: "Pending",
+  },
+  {
+    id: 2,
+    name: "Dixie Elvin",
+    age: 28,
+    gender: "M",
+    diagnosisDate: "2024-07-10",
+    status: "Approved",
+  },
+  {
+    id: 3,
+    name: "Winton Navy",
+    age: 28,
+    gender: "M",
+    diagnosisDate: "2024-04-11",
+    status: "In Progress",
+  },
+  {
+    id: 4,
+    name: "Scout Caleb",
+    age: 28,
+    gender: "M",
+    diagnosisDate: "2023-12-12",
+    status: "Released",
+  },
+  {
+    id: 5,
+    name: "Fleur Sally",
+    age: 28,
+    gender: "F",
+    diagnosisDate: "2023-11-15",
+    status: "Released",
+  },
+];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 import { Table } from "@mantine/core";
+import { useEffect, useState } from "react";
 
 export default function Home() {
-  const subjects = [
-    { id: 1, name: "Sophia Kim", age: 28, gender: "F", diagnosisDate: "2024-08-09", status: "Pending" },
-    { id: 2, name: "Dixie Elvin", age: 28, gender: "M", diagnosisDate: "2024-07-10", status: "Approved" },
-    { id: 3, name: "Winton Navy", age: 28, gender: "M", diagnosisDate: "2024-04-11", status: "In Progress" },
-    { id: 4, name: "Scout Caleb", age: 28, gender: "M", diagnosisDate: "2023-12-12", status: "Released" },
-    { id: 5, name: "Fleur Sally", age: 28, gender: "F", diagnosisDate: "2023-11-15", status: "Released" },
-  ];
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+
+  useEffect(() => {
+    // Fetch subjects from GET /api/subjects
+    fetch("/api/subjects")
+      .then((res) => res.json())
+      .then((data) => setSubjects(data));
+  }, []);
 
   const rows = subjects.map((subject) => (
     <Table.Tr key={subject.id}>
@@ -21,17 +23,17 @@ export default function Home() {
   ));
 
   return (
-      <Table>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Name</Table.Th>
-            <Table.Th>Age</Table.Th>
-            <Table.Th>Gender</Table.Th>
-            <Table.Th>Diagnosis Date</Table.Th>
-            <Table.Th>Status</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>{rows}</Table.Tbody>
-      </Table>
+    <Table>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Name</Table.Th>
+          <Table.Th>Age</Table.Th>
+          <Table.Th>Gender</Table.Th>
+          <Table.Th>Diagnosis Date</Table.Th>
+          <Table.Th>Status</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>{rows}</Table.Tbody>
+    </Table>
   );
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,8 @@
+type Subject = {
+  id: number;
+  name: string
+  age: number
+  gender: string // TODO: Use enum
+  diagnosisDate: string // TODO: Use Date type
+  status: string // TODO: Use enum
+}


### PR DESCRIPTION
This PR adds:
- Subject type in `types.d.ts` in the root of the repo
- `\api\subjects` route that returns an array of mock subject data
- Usage of the API response in the UI grid